### PR TITLE
Feature/michael/backend infrastructure

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,66 @@
+name: Deploy New App Version
+
+on:
+  push:
+    branches:
+    - main
+    paths:
+    - 'server/**'
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-session-name: github-dev-do-list-build
+          aws-region: eu-west-1
+
+      - name: Setup dotnet cli
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 6.x
+
+      - name: Dotnet publish
+        run: |
+          dotnet restore;
+          dotnet publish -r linux-x64 --configuration "Release" --self-contained "true" -o site;
+        working-directory: dev-do-list-server
+
+      - name: Package artifact
+        run: |
+          cd site;
+          zip site.zip *;
+        working-directory: dev-do-list-server
+
+      - name: Upload artifact to S3
+        run: aws s3 cp site/site.zip s3://${{ secrets.BUCKET_NAME }}/application-${{ github.run_id }}.zip
+        working-directory: dev-do-list-server
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-session-name: github-dev-do-list-build
+          aws-region: eu-west-1
+
+      - name: Deploy to Elastic Beanstalk
+        run: |
+          aws elasticbeanstalk create-application-version --application-name ${{ secrets.APP_NAME }} --version-label ${{ github.run_id }} --source-bundle S3Bucket="${{ secrets.BUCKET_NAME }}",S3Key="application-${{ github.run_id }}.zip"
+          aws elasticbeanstalk update-environment --application-name ${{ secrets.APP_NAME }} --environment-name ${{ secrets.ENV_NAME }} --version-label ${{ github.run_id }}

--- a/.github/workflows/tf-validate-backend.yml
+++ b/.github/workflows/tf-validate-backend.yml
@@ -1,0 +1,47 @@
+name: 'Terraform Format and Validate'
+
+on:
+    pull_request:
+      branches:
+        - main
+      paths:
+        - 'terraform/backend/**.tf'
+
+env:
+  TF_IN_AUTOMATION: true
+  TF_LOG: INFO
+  TF_INPUT: false
+
+jobs:
+  terrform:
+    name: 'Terraform Format and Validate'
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v4
+
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v2
+
+    - name: Terraform Init
+      id: init
+      run: terraform init
+      working-directory: terraform/backend
+
+    - name: Terraform Format
+      id: fmt
+      run: terraform fmt -check
+      working-directory: terraform/backend
+
+    # Run even if formatting fails
+    - name: Terraform Validate
+      id: validate
+      if: (success() || failure())
+      run: terraform validate
+      working-directory: terraform/backend
+  

--- a/.github/workflows/tf-validate-frontend.yml
+++ b/.github/workflows/tf-validate-frontend.yml
@@ -1,0 +1,47 @@
+name: 'Terraform Format and Validate'
+
+on:
+    pull_request:
+      branches:
+        - main
+      paths:
+        - 'terraform/frontend/**.tf'
+
+env:
+  TF_IN_AUTOMATION: true
+  TF_LOG: INFO
+  TF_INPUT: false
+
+jobs:
+  terrform:
+    name: 'Terraform Format and Validate'
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v4
+
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v2
+
+    - name: Terraform Init
+      id: init
+      run: terraform init
+      working-directory: terraform/frontend
+
+    - name: Terraform Format
+      id: fmt
+      run: terraform fmt -check
+      working-directory: terraform/frontend
+
+    # Run even if formatting fails
+    - name: Terraform Validate
+      id: validate
+      if: (success() || failure())
+      run: terraform validate
+      working-directory: terraform/frontend
+  

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,1 +1,24 @@
-Terraform
+# Terraform
+
+Terraform Cloud is used for the remote state backend:
+- It will automatically run speculative plans on pull requests if the terraform changes.
+- After merging, the plan will need to be manually reviewed and approved before being implemented.
+
+The backend folder is for the API and database infrastructure while the frontend folder is for the web server.
+
+The database is only accessible by the API server and a bastion host in the same VPC.
+The bastion host is only accessible through ssm as it is not exposing any ports and has a firewall that blocks all incoming traffic.
+To connect to the db through the bastion host:
+- Download the aws cli
+- Download the session manager plugin for the cli
+- Setup sso for the aws account using `aws configure sso`
+- Set your profile with an environment variable using `$env:AWS_PROFILE="<profile_name>"`
+- Login through sso using `aws sso login`
+- Start a port forwarding session on the bastion host to the rds instance using: 
+```
+aws ssm start-session --target <INSTANCE_ID> \ 
+--document-name AWS-StartPortForwardingSessionToRemoteHost \ 
+--parameters '{\"localPortNumber\":[\"1433\"],\"portNumber\":[\"1433\"],\"host\":[\"<DB_ENDPOINT>\"]}'
+```
+- In SQL server management studio, connect with the DB credentials to localhost:1433
+- This will let you connect to the RDS instance and run SQL queries

--- a/terraform/backend/.gitignore
+++ b/terraform/backend/.gitignore
@@ -1,0 +1,38 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version 
+# control as they are data points which are potentially sensitive and subject 
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+
+*.lock.hcl
+
+local_backend.tf

--- a/terraform/backend/data_sources.tf
+++ b/terraform/backend/data_sources.tf
@@ -1,0 +1,25 @@
+data "aws_iam_policy_document" "ec2_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+data "aws_iam_policy_document" "beanstalk_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["elasticbeanstalk.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}

--- a/terraform/backend/main.tf
+++ b/terraform/backend/main.tf
@@ -1,0 +1,301 @@
+#region Network
+# VPC
+resource "aws_vpc" "vpc" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = true
+
+  tags = { Name = "${var.naming_prefix}-vpc" }
+}
+
+# Internet Gateway
+resource "aws_internet_gateway" "ig" {
+  vpc_id = aws_vpc.vpc.id
+
+  tags = { Name = "${var.naming_prefix}-ig" }
+}
+
+# Public Subnets
+resource "aws_subnet" "public_subnets" {
+  count                   = length(var.vpc_public_subnets)
+  cidr_block              = var.vpc_public_subnets[count.index]
+  vpc_id                  = aws_vpc.vpc.id
+  map_public_ip_on_launch = true
+  availability_zone       = var.vpc_azs[count.index % length(var.vpc_azs)]
+
+  tags = { Name = "${var.naming_prefix}-public-subnet-${count.index}" }
+}
+
+# Private Subnets
+resource "aws_subnet" "private_subnets" {
+  count             = length(var.vpc_private_subnets)
+  cidr_block        = var.vpc_private_subnets[count.index]
+  vpc_id            = aws_vpc.vpc.id
+  availability_zone = var.vpc_azs[count.index % length(var.vpc_azs)]
+
+  tags = { Name = "${var.naming_prefix}-private-subnet-${count.index}" }
+}
+
+# Routing
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.vpc.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.ig.id
+  }
+
+  tags = { Name = "${var.naming_prefix}-public-route-table" }
+}
+
+resource "aws_route_table_association" "public" {
+  count          = length(aws_subnet.public_subnets[*])
+  subnet_id      = aws_subnet.public_subnets[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+# Subnet Group
+resource "aws_db_subnet_group" "db_subnet_group" {
+  name       = "${var.naming_prefix}-db-subnet-group"
+  subnet_ids = aws_subnet.private_subnets[*].id
+}
+#endregion
+
+#region Security Groups
+# Security Groups
+resource "aws_security_group" "eb_sg" {
+  name        = "${var.naming_prefix}-eb-sg"
+  description = "Security group for the Elastic Beanstalk environment"
+  vpc_id      = aws_vpc.vpc.id
+}
+
+resource "aws_vpc_security_group_ingress_rule" "eb_sg" {
+  security_group_id = aws_security_group.eb_sg.id
+  from_port         = 80
+  to_port           = 80
+  ip_protocol       = "tcp"
+  cidr_ipv4         = "0.0.0.0/0"
+}
+
+resource "aws_security_group" "rds_sg" {
+  name        = "${var.naming_prefix}-db-allow-tcp"
+  description = "Allow TCP inbound traffic from elastic beanstalk"
+  vpc_id      = aws_vpc.vpc.id
+}
+
+resource "aws_vpc_security_group_ingress_rule" "rds_sg" {
+  security_group_id            = aws_security_group.rds_sg.id
+  from_port                    = 1433
+  to_port                      = 1433
+  ip_protocol                  = "tcp"
+  referenced_security_group_id = aws_security_group.eb_sg.id
+}
+
+resource "aws_vpc_security_group_ingress_rule" "rds_sg_bastion" {
+  security_group_id            = aws_security_group.rds_sg.id
+  from_port                    = 1433
+  to_port                      = 1433
+  ip_protocol                  = "tcp"
+  referenced_security_group_id = aws_security_group.bastion_sg.id
+}
+
+resource "aws_security_group" "bastion_sg" {
+  name        = "${var.naming_prefix}-bastion-sg"
+  description = "Security group for the bastion host instance"
+  vpc_id      = aws_vpc.vpc.id
+}
+
+resource "aws_vpc_security_group_egress_rule" "bastion_sg" {
+  security_group_id = aws_security_group.bastion_sg.id
+  ip_protocol       = "-1"
+  cidr_ipv4         = "0.0.0.0/0"
+}
+#endregion
+
+#region Source Bundle Storage
+# Create an S3 bucket with versioning to store the API source bundle
+resource "aws_s3_bucket" "source" {
+  bucket        = "${var.naming_prefix}-source-bundle-bucket"
+  force_destroy = true
+  tags          = { Name = "${var.naming_prefix}-source-bucket" }
+}
+
+resource "aws_s3_bucket_versioning" "source_versioning" {
+  bucket = aws_s3_bucket.source.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+#endregion
+
+#region Database 
+# RDS
+resource "aws_db_instance" "sql_server" {
+  identifier             = "${var.naming_prefix}-db"
+  username               = var.db_username
+  password               = var.db_password
+  allocated_storage      = 20
+  storage_type           = "gp2"
+  engine                 = "sqlserver-ex"
+  engine_version         = "15.00.4345.5.v1"
+  instance_class         = "db.t3.micro"
+  db_subnet_group_name   = aws_db_subnet_group.db_subnet_group.name
+  vpc_security_group_ids = [aws_security_group.rds_sg.id]
+  license_model          = "license-included"
+  maintenance_window     = "Mon:00:00-Mon:01:00"
+  publicly_accessible    = false
+  skip_final_snapshot    = true
+  apply_immediately      = true
+  copy_tags_to_snapshot  = true
+  multi_az               = false
+}
+#endregion
+
+#region Access Management
+# Service Role
+resource "aws_iam_role" "elastic_beanstalk_service_role" {
+  name               = "${var.naming_prefix}-eb-service-role"
+  assume_role_policy = data.aws_iam_policy_document.beanstalk_assume_role.json
+}
+
+resource "aws_iam_role_policy_attachment" "elastic_beanstalk_service_role_policy_attachment" {
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSElasticBeanstalkEnhancedHealth"
+  role       = aws_iam_role.elastic_beanstalk_service_role.name
+}
+
+resource "aws_iam_role_policy_attachment" "elastic_beanstalk_managed_updates_policy_attachment" {
+  policy_arn = "arn:aws:iam::aws:policy/AWSElasticBeanstalkManagedUpdatesCustomerRolePolicy"
+  role       = aws_iam_role.elastic_beanstalk_service_role.name
+}
+
+# Key pair
+resource "aws_key_pair" "ec2_key_pair" {
+  key_name   = "${var.naming_prefix}-key-pair"
+  public_key = var.ec2_public_key
+}
+
+# EB Instance Profile
+resource "aws_iam_instance_profile" "eb_instance_profile" {
+  name = "${var.naming_prefix}-eb-instance-profile"
+  role = aws_iam_role.eb_instance_role.name
+}
+
+resource "aws_iam_role" "eb_instance_role" {
+  name               = "${var.naming_prefix}-ec2-role"
+  assume_role_policy = data.aws_iam_policy_document.ec2_assume_role.json
+}
+
+resource "aws_iam_role_policy_attachment" "eb_rds_policy_attachment" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonRDSFullAccess"
+  role       = aws_iam_role.eb_instance_role.name
+}
+
+resource "aws_iam_role_policy_attachment" "eb_s3_policy_attachment" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
+  role       = aws_iam_role.eb_instance_role.name
+}
+
+# Bastion Instance Profile
+resource "aws_iam_instance_profile" "bastion_instance_profile" {
+  name = "${var.naming_prefix}-bastion-instance-profile"
+  role = aws_iam_role.bastion_instance_role.name
+}
+
+resource "aws_iam_role" "bastion_instance_role" {
+  name               = "${var.naming_prefix}-bastion-role"
+  assume_role_policy = data.aws_iam_policy_document.ec2_assume_role.json
+}
+
+resource "aws_iam_role_policy_attachment" "bastion_ssm_policy_attachment" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+  role       = aws_iam_role.bastion_instance_role.name
+}
+
+resource "aws_iam_role_policy_attachment" "bastion_rds_policy_attachment" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonRDSFullAccess"
+  role       = aws_iam_role.bastion_instance_role.name
+}
+#endregion
+
+#region API Infrastructure
+# Elastic Beanstalk
+resource "aws_elastic_beanstalk_application" "app" {
+  name        = "${var.naming_prefix}-app"
+  description = "Beanstalk application"
+}
+
+resource "aws_elastic_beanstalk_environment" "env" {
+  name                = "${var.naming_prefix}-env"
+  application         = aws_elastic_beanstalk_application.app.name
+  solution_stack_name = "64bit Amazon Linux 2023 v3.0.5 running .NET 6"
+  cname_prefix        = var.naming_prefix
+
+  setting {
+    namespace = "aws:ec2:vpc"
+    name      = "VPCId"
+    value     = aws_vpc.vpc.id
+  }
+  setting {
+    namespace = "aws:ec2:vpc"
+    name      = "Subnets"
+    value     = join(",", aws_subnet.public_subnets[*].id)
+  }
+  setting {
+    namespace = "aws:ec2:instances"
+    name      = "InstanceTypes"
+    value     = "t3.micro"
+  }
+  setting {
+    namespace = "aws:autoscaling:launchconfiguration"
+    name      = "IamInstanceProfile"
+    value     = aws_iam_instance_profile.eb_instance_profile.name
+  }
+  setting {
+    namespace = "aws:autoscaling:launchconfiguration"
+    name      = "EC2KeyName"
+    value     = aws_key_pair.ec2_key_pair.key_name
+  }
+  setting {
+    namespace = "aws:autoscaling:launchconfiguration"
+    name      = "SecurityGroups"
+    value     = aws_security_group.eb_sg.id
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:environment"
+    name      = "EnvironmentType"
+    value     = "SingleInstance"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:environment"
+    name      = "ServiceRole"
+    value     = aws_iam_role.elastic_beanstalk_service_role.name
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "ConnectionStrings__DefaultConnection"
+    value     = var.connection_string
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:healthreporting:system"
+    name      = "SystemType"
+    value     = "basic"
+  }
+
+  depends_on = [aws_db_instance.sql_server, aws_s3_bucket.source]
+}
+#endregion
+
+#region Bastion Host
+# Bastion instance
+resource "aws_instance" "bastion" {
+  ami                         = "ami-0843a4d6dc2130849" // al2023-ami-2023.4.20240319.1-kernel-6.1-x86_64
+  instance_type               = "t3.micro"
+  subnet_id                   = aws_subnet.public_subnets[0].id // Public subnet ID
+  associate_public_ip_address = true
+  iam_instance_profile        = aws_iam_instance_profile.bastion_instance_profile.name
+  vpc_security_group_ids      = [aws_security_group.bastion_sg.id]
+
+  tags = { Name = "${var.naming_prefix}-bastion-instance" }
+
+  depends_on = [aws_db_instance.sql_server]
+}
+#endregion

--- a/terraform/backend/outputs.tf
+++ b/terraform/backend/outputs.tf
@@ -1,0 +1,3 @@
+output "domain_url" {
+  value = aws_elastic_beanstalk_environment.env.cname
+}

--- a/terraform/backend/provider.tf
+++ b/terraform/backend/provider.tf
@@ -1,0 +1,6 @@
+provider "aws" {
+  region = var.region
+  default_tags {
+    tags = var.common_tags
+  }
+}

--- a/terraform/backend/variables.tf
+++ b/terraform/backend/variables.tf
@@ -1,0 +1,56 @@
+variable "common_tags" {
+  type        = map(string)
+  description = "Common tags applied to all resources"
+}
+
+variable "region" {
+  type        = string
+  description = "The region where the resources will be deployed."
+}
+
+variable "vpc_cidr" {
+  type        = string
+  description = "The CIDR block for the VPC."
+}
+
+variable "vpc_azs" {
+  type        = list(string)
+  description = "The availability zones for the VPC."
+}
+
+variable "vpc_public_subnets" {
+  type        = list(string)
+  description = "The public subnets for the VPC."
+}
+
+variable "vpc_private_subnets" {
+  type        = list(string)
+  description = "The private subnets for the VPC."
+}
+
+variable "ec2_public_key" {
+  type        = string
+  description = "The public key to use for the EC2 instance."
+}
+
+variable "db_username" {
+  type        = string
+  description = "The username for the database."
+}
+
+variable "db_password" {
+  type        = string
+  description = "The password for the database."
+  sensitive   = true
+}
+
+variable "naming_prefix" {
+  type        = string
+  description = "The prefix to use for naming resources."
+}
+
+variable "connection_string" {
+  type        = string
+  description = "The connection string for the database."
+  sensitive   = true
+}

--- a/terraform/backend/versions.tf
+++ b/terraform/backend/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.4"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/terraform/frontend/.gitignore
+++ b/terraform/frontend/.gitignore
@@ -1,0 +1,38 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version 
+# control as they are data points which are potentially sensitive and subject 
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+
+*.lock.hcl
+
+local_backend.tf


### PR DESCRIPTION
# Terraform

Terraform Cloud is used for the remote state backend:
- It will automatically run speculative plans on pull requests if the terraform changes.
- After merging, the plan will need to be manually reviewed and approved before being implemented.

The backend folder is for the API and database infrastructure while the frontend folder is for the web server.

The database is only accessible by the API server and a bastion host in the same VPC.
The bastion host is only accessible through ssm as it is not exposing any ports and has a firewall that blocks all incoming traffic.
To connect to the db through the bastion host:
- Download the aws cli
- Download the session manager plugin for the cli
- Setup sso for the aws account using `aws configure sso`
- Set your profile with an environment variable using `$env:AWS_PROFILE="<profile_name>"`
- Login through sso using `aws sso login`
- Start a port forwarding session on the bastion host to the rds instance using: 
```
aws ssm start-session --target <INSTANCE_ID> \ 
--document-name AWS-StartPortForwardingSessionToRemoteHost \ 
--parameters '{\"localPortNumber\":[\"1433\"],\"portNumber\":[\"1433\"],\"host\":[\"<DB_ENDPOINT>\"]}'
```
- In SQL server management studio, connect with the DB credentials to localhost:1433
- This will let you connect to the RDS instance and run SQL queries