### PR TITLE
Added install step to frontend workflow deployment

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -32,6 +32,10 @@ jobs:
         with:
           node-version: 20.x
 
+      - name: Install dependencies
+        run: npm install
+        working-directory: dev-do-list-frontend
+
       - name: Build
         run: npm run build
         working-directory: dev-do-list-frontend


### PR DESCRIPTION
- Workflow was failing because it couldn't find vite
- Adding npm install before building should resolve this issue