### PR TITLE
Implemented Oauth Flow in Frontend

### DIFF
--- a/DevDoListBlazorApp/Components/Layout/LoginLayout.razor
+++ b/DevDoListBlazorApp/Components/Layout/LoginLayout.razor
@@ -1,0 +1,5 @@
+﻿@inherits LayoutComponentBase
+
+<div class="login-layout">
+    @Body
+</div>

--- a/DevDoListBlazorApp/Components/Layout/LoginLayout.razor.css
+++ b/DevDoListBlazorApp/Components/Layout/LoginLayout.razor.css
@@ -1,0 +1,5 @@
+.login-layout {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}

--- a/DevDoListBlazorApp/Components/Layout/NavMenu.razor
+++ b/DevDoListBlazorApp/Components/Layout/NavMenu.razor
@@ -9,12 +9,6 @@
 <div class="nav-scrollable" onclick="document.querySelector('.navbar-toggler').click()">
     <nav class="flex-column">
         <div class="nav-item px-3">
-            <NavLink class="nav-link" href="" Match="NavLinkMatch.All">
-                Login
-            </NavLink>
-        </div>
-
-        <div class="nav-item px-3">
             <NavLink class="nav-link" href="dashboard">
                 Dashboard
             </NavLink>

--- a/DevDoListBlazorApp/Components/Pages/Dashboard.razor
+++ b/DevDoListBlazorApp/Components/Pages/Dashboard.razor
@@ -3,6 +3,9 @@
 @using System.Collections.Generic
 @using System.Linq
 @using System
+@using DevDoListBlazorApp.Services;
+@inject LocalStorageService LocalStorageService;
+@inject NavigationManager NavigationManager;
 
 <div class="dashboard-page">
         <div class="dash-container">
@@ -37,6 +40,22 @@
     string errorNotes = "";
     string errorCategories = "";
     bool showAscDesc = false;
+    bool checkedLoggedIn = false;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender) // Redirects to login page if they do not have a token
+    {
+        if (firstRender && !checkedLoggedIn)
+        {
+            // Check if the user is not logged in
+            var jwtToken = await LocalStorageService.GetItem<string>("accessToken");
+            if (string.IsNullOrEmpty(jwtToken))
+            {
+                // User is not logged in, redirect to login page
+                NavigationManager.NavigateTo("/");
+            }
+            checkedLoggedIn = true;
+        }
+    }
 
     // Navigation
 

--- a/DevDoListBlazorApp/Components/Pages/Login.razor
+++ b/DevDoListBlazorApp/Components/Pages/Login.razor
@@ -1,8 +1,10 @@
 ﻿@page "/"
+@layout LoginLayout
 @rendermode InteractiveServer
 @using Newtonsoft.Json
 @using Newtonsoft.Json.Linq;
 @using DevDoListBlazorApp.Services;
+@using DevDoListBlazorApp.Components.Layout;
 @using System.Web;
 @inject HttpClient HttpClient
 @inject LocalStorageService LocalStorageService

--- a/DevDoListBlazorApp/Components/Pages/Login.razor
+++ b/DevDoListBlazorApp/Components/Pages/Login.razor
@@ -12,12 +12,12 @@
     <div class="input-container-login">
         @if (VerificationUri == null && UserCode == null)
         {
-          <div class="input-container-title-login">
-            Login to your GitHub account
-          </div>
-          <div class="login-button-container">
-            <button class="login-button" @onclick="HandleLogin">Login</button>
-          </div>
+            <div class="input-container-title-login">
+                Login to your GitHub account
+            </div>
+            <div class="login-button-container">
+                <button class="login-button" @onclick="HandleLogin">Login</button>
+            </div>
         }
         else
         {
@@ -30,119 +30,130 @@
             </div>
         }
     </div>
-    
 </div>
 
 @code {
-  private string VerificationUri { get; set; }
-  private string UserCode { get; set; }
+    private string VerificationUri { get; set; }
+    private string UserCode { get; set; }
+    private bool checkedLoggedIn = false;
 
-  private async Task HandleLogin()
-  {
-    var request = new HttpRequestMessage(HttpMethod.Post, "https://github.com/login/device/code");
-    string clientId = GetClientId();
-    request.Content = new FormUrlEncodedContent(new Dictionary<string, string>
+    protected override async Task OnAfterRenderAsync(bool firstRender) // Takes user straight to dashboard page if they already have an access token stored
+    {
+        if (firstRender && !checkedLoggedIn)
+        {
+            // Check if the user is already logged in
+            var jwtToken = await LocalStorageService.GetItem<string>("accessToken");
+            if (!string.IsNullOrEmpty(jwtToken))
+            {
+                // User is already logged in, redirect to dashboard
+                NavigationManager.NavigateTo("/dashboard");
+            }
+            checkedLoggedIn = true;
+        }
+    }
+
+    private async Task HandleLogin()
+    {
+        var request = new HttpRequestMessage(HttpMethod.Post, "https://github.com/login/device/code");
+        string clientId = GetClientId();
+        request.Content = new FormUrlEncodedContent(new Dictionary<string, string>
         {
             { "client_id", clientId },
             { "scope", "user" }
         });
-    var response = await HttpClient.SendAsync(request);
-    if (response.IsSuccessStatusCode)
-    {
-      var responseContent = await response.Content.ReadAsStringAsync();
-      var jsonResponse = HttpUtility.ParseQueryString(responseContent);
-
-      var deviceCode = jsonResponse["device_code"].ToString();
-      UserCode = jsonResponse["user_code"].ToString();
-      VerificationUri = jsonResponse["verification_uri"].ToString();
-      await InvokeAsync(StateHasChanged); // Allows the page to rerender and show the user code and url
-
-      var bearerToken = await GetBearerToken(deviceCode);
-
-      await SetJwtToken(bearerToken);
-
-      NavigationManager.NavigateTo("/dashboard");
-    }
-    }
-
-  
-
-  private string GetClientId()
-  {
-      var clientId = Environment.GetEnvironmentVariable("CLIENT_ID");
-      if (clientId is null)
-      {
-        throw new Exception("Client id does not exist");
-      }
-      return clientId;
-  }
-
-  private async Task<string> GetBearerToken(string deviceCode)
-  {
-      int pollingInterval = 5000; // 5 seconds
-
-      while (true)
-      {
-        try
+        var response = await HttpClient.SendAsync(request);
+        if (response.IsSuccessStatusCode)
         {
-            // Make a request to GitHub's token endpoint to check authentication status
-            var request = new HttpRequestMessage(HttpMethod.Post, "https://github.com/login/oauth/access_token");
-            string clientId = GetClientId();
-            request.Content = new FormUrlEncodedContent(new Dictionary<string, string>
+            var responseContent = await response.Content.ReadAsStringAsync();
+            var jsonResponse = HttpUtility.ParseQueryString(responseContent);
+
+            var deviceCode = jsonResponse["device_code"].ToString();
+            UserCode = jsonResponse["user_code"].ToString();
+            VerificationUri = jsonResponse["verification_uri"].ToString();
+            await InvokeAsync(StateHasChanged); // Allows the page to rerender and show the user code and url
+
+            var bearerToken = await GetBearerToken(deviceCode);
+
+            await SetJwtToken(bearerToken);
+
+            NavigationManager.NavigateTo("/dashboard");
+        }
+    }
+
+    private string GetClientId()
+    {
+        var clientId = Environment.GetEnvironmentVariable("CLIENT_ID");
+        if (clientId is null)
+        {
+            throw new Exception("Client id does not exist");
+        }
+        return clientId;
+    }
+
+    private async Task<string> GetBearerToken(string deviceCode)
+    {
+        int pollingInterval = 5000; // 5 seconds
+
+        while (true)
+        {
+            try
             {
-                { "client_id", clientId },
-                { "device_code", deviceCode },
-                { "grant_type", "urn:ietf:params:oauth:grant-type:device_code" }
-            });
-
-            var response = await HttpClient.SendAsync(request);
-
-            if (response.IsSuccessStatusCode)
-            {
-                var responseContent = await response.Content.ReadAsStringAsync();
-                var jsonResponse = HttpUtility.ParseQueryString(responseContent);
-
-                // Check if authentication is successful
-                if (jsonResponse.AllKeys.Contains("access_token"))
+                // Make a request to GitHub's token endpoint to check authentication status
+                var request = new HttpRequestMessage(HttpMethod.Post, "https://github.com/login/oauth/access_token");
+                string clientId = GetClientId();
+                request.Content = new FormUrlEncodedContent(new Dictionary<string, string>
                 {
-                    // Authentication is successful, retrieve the bearer token
-                    var bearerToken = jsonResponse["access_token"].ToString();
+                    { "client_id", clientId },
+                    { "device_code", deviceCode },
+                    { "grant_type", "urn:ietf:params:oauth:grant-type:device_code" }
+                });
 
-                    return bearerToken;
+                var response = await HttpClient.SendAsync(request);
+
+                if (response.IsSuccessStatusCode)
+                {
+                    var responseContent = await response.Content.ReadAsStringAsync();
+                    var jsonResponse = HttpUtility.ParseQueryString(responseContent);
+
+                    // Check if authentication is successful
+                    if (jsonResponse.AllKeys.Contains("access_token"))
+                    {
+                        // Authentication is successful, retrieve the bearer token
+                        var bearerToken = jsonResponse["access_token"].ToString();
+
+                        return bearerToken;
+                    }
+                }
+                else
+                {
+                  // Handle non-successful response status codes
                 }
             }
-            else
+            catch (Exception ex)
             {
-              // Handle non-successful response status codes
-              // For example, log the error or retry the request
+              // Handle exceptions
+            }
+
+          // Wait for the next polling interval before making the next request
+          await Task.Delay(pollingInterval);
+        }
+    }
+
+    private async Task SetJwtToken(string bearerToken)
+    {
+        var token_request = new HttpRequestMessage(HttpMethod.Post, "http://dev-do-list-backend.eu-west-1.elasticbeanstalk.com/authenticate");
+        token_request.Headers.Add("Authorization", $"Bearer {bearerToken}");
+        var token_response = await HttpClient.SendAsync(token_request);
+        if (token_response.IsSuccessStatusCode)
+        {
+            var responseContent = await token_response.Content.ReadAsStringAsync();
+            var jsonResponse = JObject.Parse(responseContent);
+
+            if (jsonResponse.ContainsKey("access_token"))
+            {
+                var jwtToken = jsonResponse["access_token"].ToString();
+                await LocalStorageService.SetItem("accessToken", jwtToken);
             }
         }
-        catch (Exception ex)
-        {
-          // Handle exceptions
-          // For example, log the exception or retry the request
-        }
-
-        // Wait for the next polling interval before making the next request
-        await Task.Delay(pollingInterval);
-      }
-  }
-
-  private async Task SetJwtToken(string bearerToken)
-  {
-      var token_request = new HttpRequestMessage(HttpMethod.Post, "http://dev-do-list-backend.eu-west-1.elasticbeanstalk.com/authenticate");
-      token_request.Headers.Add("Authorization", $"Bearer {bearerToken}");
-      var token_response = await HttpClient.SendAsync(token_request);
-      if (token_response.IsSuccessStatusCode)
-      {
-          var responseContent = await token_response.Content.ReadAsStringAsync();
-          var jsonResponse = JObject.Parse(responseContent);
-
-          if (jsonResponse.ContainsKey("access_token"))
-          {
-              var jwtToken = jsonResponse["access_token"].ToString();
-              await LocalStorageService.SetItem("accessToken", jwtToken);
-          }
-      }
-  }
+    }
 }

--- a/DevDoListBlazorApp/Components/Pages/Login.razor
+++ b/DevDoListBlazorApp/Components/Pages/Login.razor
@@ -12,7 +12,7 @@
 
 <div class="login-page">
     <div class="input-container-login">
-        @if (VerificationUri == null && UserCode == null)
+        @if (string.IsNullOrEmpty(VerificationUri) && string.IsNullOrEmpty(UserCode))
         {
             <div class="input-container-title-login">
                 Login to your GitHub account
@@ -47,7 +47,6 @@
             var jwtToken = await LocalStorageService.GetItem<string>("accessToken");
             if (!string.IsNullOrEmpty(jwtToken))
             {
-                // User is already logged in, redirect to dashboard
                 NavigationManager.NavigateTo("/dashboard");
             }
             checkedLoggedIn = true;
@@ -95,8 +94,10 @@
     private async Task<string> GetBearerToken(string deviceCode)
     {
         int pollingInterval = 5000; // 5 seconds
+        int maxRetries = 5;
+        int retryCount = 0; // Incremenet on failures to avoid infinite loop
 
-        while (true)
+        while (retryCount < maxRetries)
         {
             try
             {
@@ -120,25 +121,26 @@
                     // Check if authentication is successful
                     if (jsonResponse.AllKeys.Contains("access_token"))
                     {
-                        // Authentication is successful, retrieve the bearer token
-                        var bearerToken = jsonResponse["access_token"].ToString();
+                        string bearerToken = jsonResponse["access_token"].ToString();
 
                         return bearerToken;
                     }
                 }
                 else
                 {
-                  // Handle non-successful response status codes
+                    retryCount++;
                 }
             }
             catch (Exception ex)
             {
-              // Handle exceptions
+                retryCount++;
             }
 
-          // Wait for the next polling interval before making the next request
-          await Task.Delay(pollingInterval);
+            // Wait for the next polling interval before making the next request
+            await Task.Delay(pollingInterval);
         }
+        
+        throw new InvalidOperationException("Maximum retry attempts exceeded.");
     }
 
     private async Task SetJwtToken(string bearerToken)

--- a/DevDoListBlazorApp/Components/Pages/Login.razor
+++ b/DevDoListBlazorApp/Components/Pages/Login.razor
@@ -9,6 +9,7 @@
 @inject HttpClient HttpClient
 @inject LocalStorageService LocalStorageService
 @inject NavigationManager NavigationManager
+@inject IJSRuntime JsRuntime
 
 <div class="login-page">
     <div class="input-container-login">
@@ -73,11 +74,18 @@
             VerificationUri = jsonResponse["verification_uri"].ToString();
             await InvokeAsync(StateHasChanged); // Allows the page to rerender and show the user code and url
 
-            var bearerToken = await GetBearerToken(deviceCode);
+            try
+            {
+                var bearerToken = await GetBearerToken(deviceCode);
+                await SetJwtToken(bearerToken);
 
-            await SetJwtToken(bearerToken);
-
-            NavigationManager.NavigateTo("/dashboard");
+                NavigationManager.NavigateTo("/dashboard");
+            }
+            catch(InvalidOperationException ex)
+            {
+                await JsRuntime.InvokeVoidAsync("alert", ex.Message); // Alert
+                return;
+            }
         }
     }
 
@@ -140,7 +148,7 @@
             await Task.Delay(pollingInterval);
         }
         
-        throw new InvalidOperationException("Maximum retry attempts exceeded.");
+        throw new InvalidOperationException("Something went wrong during the authentication process.");
     }
 
     private async Task SetJwtToken(string bearerToken)

--- a/DevDoListBlazorApp/Components/Pages/Login.razor
+++ b/DevDoListBlazorApp/Components/Pages/Login.razor
@@ -1,21 +1,148 @@
 ﻿@page "/"
 @rendermode InteractiveServer
+@using Newtonsoft.Json
+@using Newtonsoft.Json.Linq;
+@using DevDoListBlazorApp.Services;
+@using System.Web;
+@inject HttpClient HttpClient
+@inject LocalStorageService LocalStorageService
+@inject NavigationManager NavigationManager
 
 <div class="login-page">
-        <div class="input-container-login">
-            <div class="input-container-title-login">
-                Login to your GitHub account
+    <div class="input-container-login">
+        @if (VerificationUri == null && UserCode == null)
+        {
+          <div class="input-container-title-login">
+            Login to your GitHub account
+          </div>
+          <div class="login-button-container">
+            <button class="login-button" @onclick="HandleLogin">Login</button>
+          </div>
+        }
+        else
+        {
+            <div class="login-container-user-code">
+                @UserCode
             </div>
-            <div class="login-button-container">
-                <button class="login-button" @onclick="HandleLogin">Login</button>
+            <div class="login-container-link">
+                <p>Enter the code at:</p>
+                <a href="@VerificationUri" target="_blank">@VerificationUri</a>
             </div>
-        </div>
+        }
+    </div>
+    
 </div>
 
 @code {
-    private void HandleLogin()
-    {
-        // TODO: Implement login functionality with Oaurth
+  private string VerificationUri { get; set; }
+  private string UserCode { get; set; }
 
+  private async Task HandleLogin()
+  {
+    var request = new HttpRequestMessage(HttpMethod.Post, "https://github.com/login/device/code");
+    string clientId = GetClientId();
+    request.Content = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            { "client_id", clientId },
+            { "scope", "user" }
+        });
+    var response = await HttpClient.SendAsync(request);
+    if (response.IsSuccessStatusCode)
+    {
+      var responseContent = await response.Content.ReadAsStringAsync();
+      var jsonResponse = HttpUtility.ParseQueryString(responseContent);
+
+      var deviceCode = jsonResponse["device_code"].ToString();
+      UserCode = jsonResponse["user_code"].ToString();
+      VerificationUri = jsonResponse["verification_uri"].ToString();
+      await InvokeAsync(StateHasChanged); // Allows the page to rerender and show the user code and url
+
+      var bearerToken = await GetBearerToken(deviceCode);
+
+      await SetJwtToken(bearerToken);
+
+      NavigationManager.NavigateTo("/dashboard");
     }
+    }
+
+  
+
+  private string GetClientId()
+  {
+      var clientId = Environment.GetEnvironmentVariable("CLIENT_ID");
+      if (clientId is null)
+      {
+        throw new Exception("Client id does not exist");
+      }
+      return clientId;
+  }
+
+  private async Task<string> GetBearerToken(string deviceCode)
+  {
+      int pollingInterval = 5000; // 5 seconds
+
+      while (true)
+      {
+        try
+        {
+            // Make a request to GitHub's token endpoint to check authentication status
+            var request = new HttpRequestMessage(HttpMethod.Post, "https://github.com/login/oauth/access_token");
+            string clientId = GetClientId();
+            request.Content = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                { "client_id", clientId },
+                { "device_code", deviceCode },
+                { "grant_type", "urn:ietf:params:oauth:grant-type:device_code" }
+            });
+
+            var response = await HttpClient.SendAsync(request);
+
+            if (response.IsSuccessStatusCode)
+            {
+                var responseContent = await response.Content.ReadAsStringAsync();
+                var jsonResponse = HttpUtility.ParseQueryString(responseContent);
+
+                // Check if authentication is successful
+                if (jsonResponse.AllKeys.Contains("access_token"))
+                {
+                    // Authentication is successful, retrieve the bearer token
+                    var bearerToken = jsonResponse["access_token"].ToString();
+
+                    return bearerToken;
+                }
+            }
+            else
+            {
+              // Handle non-successful response status codes
+              // For example, log the error or retry the request
+            }
+        }
+        catch (Exception ex)
+        {
+          // Handle exceptions
+          // For example, log the exception or retry the request
+        }
+
+        // Wait for the next polling interval before making the next request
+        await Task.Delay(pollingInterval);
+      }
+  }
+
+  private async Task SetJwtToken(string bearerToken)
+  {
+      var token_request = new HttpRequestMessage(HttpMethod.Post, "http://dev-do-list-backend.eu-west-1.elasticbeanstalk.com/authenticate");
+      token_request.Headers.Add("Authorization", $"Bearer {bearerToken}");
+      var token_response = await HttpClient.SendAsync(token_request);
+      if (token_response.IsSuccessStatusCode)
+      {
+          var responseContent = await token_response.Content.ReadAsStringAsync();
+          var jsonResponse = JObject.Parse(responseContent);
+
+          if (jsonResponse.ContainsKey("access_token"))
+          {
+              var jwtToken = jsonResponse["access_token"].ToString();
+              await LocalStorageService.SetItem("accessToken", jwtToken);
+          }
+      }
+  }
 }

--- a/DevDoListBlazorApp/Components/Pages/Login.razor.css
+++ b/DevDoListBlazorApp/Components/Pages/Login.razor.css
@@ -59,3 +59,27 @@
   font-weight: 650;
   background-color: #6a61c0;
 }
+
+.login-container-user-code {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 50vw;
+  height: 20vh;
+  color: #434343;
+  text-align: center;
+  font-size: 1.5em;
+  font-style: normal;
+  font-weight: 700;
+  line-height: normal;
+}
+
+.login-container-link {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  text-align: center;
+  font-size: 1.2em;
+  font-weight: 400;
+}

--- a/DevDoListBlazorApp/DevDoListBlazorApp.csproj
+++ b/DevDoListBlazorApp/DevDoListBlazorApp.csproj
@@ -1,9 +1,13 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
 
 </Project>

--- a/DevDoListBlazorApp/DevDoListBlazorApp.sln
+++ b/DevDoListBlazorApp/DevDoListBlazorApp.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.8.34511.84
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DevDoListBlazorApp", "DevDoListBlazorApp.csproj", "{0FA8D854-B0DC-4FBF-B1E9-42F9C25A24DF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DevDoListBlazorApp", "DevDoListBlazorApp.csproj", "{0FA8D854-B0DC-4FBF-B1E9-42F9C25A24DF}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/DevDoListBlazorApp/Program.cs
+++ b/DevDoListBlazorApp/Program.cs
@@ -1,10 +1,13 @@
 using DevDoListBlazorApp.Components;
+using DevDoListBlazorApp.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();
+builder.Services.AddHttpClient();
+builder.Services.AddScoped<LocalStorageService, LocalStorageService>();
 
 var app = builder.Build();
 

--- a/DevDoListBlazorApp/Services/LocalStorageService.cs
+++ b/DevDoListBlazorApp/Services/LocalStorageService.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.JSInterop;
+using System.Text.Json;
+
+namespace DevDoListBlazorApp.Services
+{
+  public interface ILocalStorageService
+  {
+    Task<T> GetItem<T>(string key);
+    Task SetItem<T>(string key, T value);
+    Task RemoveItem(string key);
+  }
+
+  public class LocalStorageService : ILocalStorageService
+  {
+    private IJSRuntime _jsRuntime;
+
+    public LocalStorageService(IJSRuntime jsRuntime)
+    {
+      _jsRuntime = jsRuntime;
+    }
+
+    public async Task<T> GetItem<T>(string key)
+    {
+      var json = await _jsRuntime.InvokeAsync<string>("localStorage.getItem", key);
+
+      if (json == null)
+        return default;
+
+      return JsonSerializer.Deserialize<T>(json);
+    }
+
+    public async Task SetItem<T>(string key, T value)
+    {
+      await _jsRuntime.InvokeVoidAsync("localStorage.setItem", key, JsonSerializer.Serialize(value));
+    }
+
+    public async Task RemoveItem(string key)
+    {
+      await _jsRuntime.InvokeVoidAsync("localStorage.removeItem", key);
+    }
+  }
+}


### PR DESCRIPTION
- Login page is its own layout that excludes other layouts such as the nav bar
- Removed login from nav bar
- Created local storage service to store the jwt token
- You get directed straight to the dashboard if you have logged in previously and your token hasn't expired
- If you try to access the dashboard page before logging in, it redirects you back to the login page
- Added basic exception handling if there are errors when trying to validate that the user is authorized